### PR TITLE
Set Java heap size lower than default

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -82,4 +82,11 @@ if [ ! -z "$RDS_HOSTNAME" ]; then
     export MB_DB_PORT=$RDS_PORT
 fi
 
+limit=$(ulimit -u)
+case $limit in
+256)   # Free, Hobby, or 1X Dyno
+  JAVA_OPTS="-Xmx256m -Xss512k $JAVA_OPTS"
+  ;;
+esac
+
 exec java -Dfile.encoding=UTF-8 $JAVA_OPTS -jar ./target/uberjar/metabase.jar


### PR DESCRIPTION
The addition of the JAVA_OPTS in this PR will prevent R14 and R10 errors I've seen. The default JVM heap size is too high for Heroku's 512mb RAM on a free dyno. But the app seems to work fine with this heap setting.

Also, I gave the source project a try:

```
$ git clone https://github.com/metabase/metabase
$ cd metabase
$ heroku create
$ git push heroku master
```

And it worked on the first attempt. So I'm curious why the [Heroku Button](http://www.metabase.com/start/heroku.html) uses this repo instead? Is just because it's faster?

Thanks!
