### PR TITLE
Add a custom buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/metabase/metabase-deploy/tree/v0.22.2)
+[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)

--- a/app.json
+++ b/app.json
@@ -18,6 +18,9 @@
   "buildpacks": [
     {
       "url": "https://github.com/heroku/heroku-buildpack-jvm-common.git"
+    },
+    {
+      "url": "https://github.com/jkutner/metabase-buildpack"
     }
   ]
 }


### PR DESCRIPTION
This change adds a custom buildpack, and removes the JAR file from Git.

The buildpack is located here:
https://github.com/jkutner/metabase-buildpack

It copies the JAR file from http://downloads.metabase.com into the Heroku slug (rather than pulling it from Github).