### PR TITLE
Use heroku/jvm releases instead of master

### DIFF
--- a/app.json
+++ b/app.json
@@ -18,7 +18,7 @@
   ],
   "buildpacks": [
     {
-      "url": "https://github.com/heroku/heroku-buildpack-jvm-common.git"
+      "url": "heroku/jvm"
     },
     {
       "url": "https://github.com/metabase/metabase-buildpack"


### PR DESCRIPTION
This updates the buildpack configuration to use `heroku/jvm` instead of the master branch of the buildpack repo. 

This should fix https://github.com/metabase/metabase/issues/11797 where there was temporary breakage due to the master branch temporarily having an issue that impacted the user until it was fixed.