### PR TITLE
Set timezone using the JAVA_TIMEZONE var.

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -108,4 +108,10 @@ JAVA_OPTS+=" -server"                  # Run in server mode. This is the default
 JAVA_OPTS+=" -Djava.awt.headless=true" # don't try to start AWT. Not sure this does anything but better safe than wasting memory
 JAVA_OPTS+=" -Dfile.encoding=UTF-8"    # Use UTF-8
 
+# Set timezone using the JAVA_TIMEZONE variable if present
+if [ "$JAVA_TIMEZONE"]; then
+    echo "  -> Timezone setting detected: $JAVA_TIMEZONE"
+    JAVA_OPTS+=" -Duser.timezone=$JAVA_TIMEZONE"
+fi
+
 exec java $JAVA_OPTS -jar ./target/uberjar/metabase.jar


### PR DESCRIPTION
Hello from Every.org! Hope y'all are doing well :)

The Metabase [docs for Docker](https://www.metabase.com/docs/latest/operations-guide/running-metabase-on-docker.html) recommend using the `JAVA_TIMEZONE` env var to set the reporting timezone, but there is no easy way (as far as I can tell) to similarly and easily set the timezone in Heroku. This modifies the deploy script for Heroku to consume the same environment variable!