### PR TITLE
Update app.json to point to our fork

### DIFF
--- a/app.json
+++ b/app.json
@@ -21,7 +21,7 @@
       "url": "heroku/jvm"
     },
     {
-      "url": "https://github.com/metabase/metabase-buildpack"
+      "url": "https://github.com/CareAcademy/metabase-buildpack"
     }
   ]
 }


### PR DESCRIPTION
Our fork of the buildpack is in https://github.com/CareAcademy/metabase-buildpack since they stopped supporting Heroku deploys.